### PR TITLE
Enable opt-in X11 builds

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: skiagd
 Title: Creative Coding Pipeline for R
-Version: 0.1.8.4
+Version: 0.1.8.5
 Authors@R: c(
     person("Akiru", "Kato", , "paithiov909@gmail.com", role = c("aut", "cre")),
     person("Jeroen", "Ooms", role = "cph")

--- a/configure
+++ b/configure
@@ -60,6 +60,8 @@ if [ -n "${SAVVY_FEATURES}" ]; then
 fi
 
 ENABLE_X11=false
+# Check if features include "skiagd-x11".
+# Note that this ignores comma-separated form, though Cargo actually supports it.
 for feature in ${SAVVY_FEATURES}; do
   if [ "${feature}" = "skiagd-x11" ]; then
     ENABLE_X11=true

--- a/configure
+++ b/configure
@@ -59,6 +59,13 @@ if [ -n "${SAVVY_FEATURES}" ]; then
   FEATURE_FLAGS="--features '${SAVVY_FEATURES}'"
 fi
 
+ENABLE_X11=false
+for feature in ${SAVVY_FEATURES}; do
+  if [ "${feature}" = "skiagd-x11" ]; then
+    ENABLE_X11=true
+  fi
+done
+
 # Set macOS deployment target for the Rust cc crate.
 #
 # The cc crate (used by savvy's build.rs to compile unwind_protect_wrapper.c)
@@ -156,8 +163,35 @@ fi
 
 # --- End -----
 
+X11_LIBS=""
+if [ "${ENABLE_X11}" = "true" ]; then
+  if ! command -v pkg-config >/dev/null 2>&1; then
+    echo "-------------- ERROR: CONFIGURATION FAILED --------------------"
+    echo ""
+    echo "SAVVY_FEATURES includes 'skiagd-x11', but pkg-config is not available."
+    echo "Install pkg-config and the OpenGL development packages, then retry."
+    echo ""
+    echo "---------------------------------------------------------------"
+    exit 1
+  fi
+
+  X11_LIBS=`pkg-config --libs --silence-errors gl`
+  if [ $? -ne 0 ] || [ -z "${X11_LIBS}" ]; then
+    echo "-------------- ERROR: CONFIGURATION FAILED --------------------"
+    echo ""
+    echo "SAVVY_FEATURES includes 'skiagd-x11', but pkg-config could not find OpenGL."
+    echo "Install the OpenGL development packages or set PKG_CONFIG_PATH."
+    echo ""
+    echo "---------------------------------------------------------------"
+    exit 1
+  fi
+
+  echo "Using X11_LIBS=${X11_LIBS}"
+fi
+
 sed \
   -e "s|@libs@|$PKG_LIBS|" \
+  -e "s|@x11_libs@|$X11_LIBS|" \
   -e "s|@SYS@|$SYS|g" \
   -e "s/@TARGET@/${TARGET}/" \
   -e "s/@PROFILE@/${PROFILE}/" \

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -10,7 +10,7 @@ TARGET_DIR = $(CURDIR)/rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/$(subst dev,debug,$(PROFILE))
 STATLIB = $(LIBDIR)/libskiagd.a
 PKG_CPPFLAGS = -pthread
-PKG_LIBS = -L$(LIBDIR) -lskiagd @libs@ $(@SYS@_LIBS) -pthread
+PKG_LIBS = -L$(LIBDIR) -lskiagd @libs@ $(@SYS@_LIBS) @x11_libs@ -pthread
 
 CARGO_BUILD_ARGS = --lib --profile $(PROFILE) $(FEATURE_FLAGS) --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -6,10 +6,13 @@ edition = "2024"
 [lib]
 crate-type = ["staticlib", "lib"]
 
+[features]
+skiagd-x11 = ["skia-safe/x11"]
+
 [dependencies]
 anyhow = "1.0"
 savvy = "0.10"
-skia-safe = { version = "=0.91.1", features = ["textlayout"] }
+skia-safe = { version = "=0.91.1" }
 
 [profile.release]
 # By default, on release build, savvy terminates the R session when a panic


### PR DESCRIPTION
This PR adds an experimental `skiagd-x11` Cargo feature that can be enabled through the `SAVVY_FEATURES` environment variable.

For example:

```r
Sys.setenv(SAVVY_FEATURES = "skiagd-x11")
devtools::install(".")
```

This enables the `x11` feature of `skia-safe`. Note that an OpenGL development environment is still required to build it, although skiagd itself does not provide any window-management functionality and therefore does not require an X11.

### Motivation

I originally explored this as a possible way to improve rendering performance by switching the backend.

However, skiagd currently reconstructs the rendering surface for each drawing operation. A typical pipeline is:

1. Create a new surface.
2. Replay the recorded `Picture`.
3. Draw the new primitives.
4. Record and return a new `Picture`.

Because the surface is recreated repeatedly, enabling the X11 backend generally provides little benefit and can even be slightly slower in some workloads.

Despite the limited practical impact at the moment, I think exposing this as an optional build feature is still useful for experimentation and future backend investigations, while keeping the default build unchanged.
